### PR TITLE
Fix links to Mike's blog in the Readme

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -124,4 +124,4 @@ Sometimes, there may be artefacts left over when switching branches. These are f
 
     git clean -dxf
     
-This deletes all files that are not tracked by git.q
+This deletes all files that are not tracked by git.


### PR DESCRIPTION
There was a small error in the Markdown. Don't know if it was intentional or not, but the link that it was supposed to point to is active.
