### PR TITLE
Don't escape space as "+" anymore.  Though it looks nicer for web URLs, ...

### DIFF
--- a/KSURLQueryUtilities.m
+++ b/KSURLQueryUtilities.m
@@ -120,24 +120,18 @@
  
  RFC2396:  Within a query component, the characters ";", "/", "?", ":", "@", "&", "=", "+", ",", and "$" are reserved.
  
+ Changed to NOT convert space into + ... while this is fine for web parameters, it doesn't work on mail clients reliably (e.g. mailto:foo@bar.com?subject=Hi+There+Mom)
  
  */
 
 - (NSString *)ks_stringByAddingQueryComponentPercentEscapes;
 {
-    CFStringRef firstPass = CFURLCreateStringByAddingPercentEscapes(NULL,
+    CFStringRef converted = CFURLCreateStringByAddingPercentEscapes(NULL,
                                                                     (CFStringRef)self,
-                                                                    CFSTR(" "),
+                                                                    NULL,
                                                                     CFSTR(";/?:@&=+,$%"),
                                                                     kCFStringEncodingUTF8);
-    
-    NSMutableString *result = [(NSString *)firstPass mutableCopy];
-    CFRelease(firstPass);
-    [result replaceOccurrencesOfString:@" "
-                            withString:@"+"
-                               options:NSLiteralSearch
-                                 range:NSMakeRange(0, [result length])];
-    
+    NSString *result = NSMakeCollectable(converted);
     return [result autorelease];
 }
 


### PR DESCRIPTION
...it doesn't seem to work consistently across mail clients for URLs like mailto:foo@bar.com?subject=Hi+there+Mom so instead, just let the CF method we invoke do its usual thing in converting spaces to %20.
