### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -198,7 +198,7 @@ And IFUnicodeURL in turn relies upon VeriSign's IDN SDK:
 
 /*************************************************************************/
 /*                                                                       */
-/* VeriSign XCode (encode/decode) IDN Library                            */
+/* VeriSign Xcode (encode/decode) IDN Library                            */
 /*                                                                       */
 /* A library for encoding / decoding of domain strings.                  */
 /*                                                                       */


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
